### PR TITLE
fix(docker): removed `GH_APP_PEM` env var from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY swingletree.conf.yaml .
 # add entrypoint script
 COPY docker/entrypoint.sh .
 
-ENTRYPOINT [ "/bin/sh", "entrypoint.sh" ]
+ENTRYPOINT [ "node", "main.js" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,0 @@
-echo "$GH_APP_PEM" > ./gh-app.pem
-
-node main.js $@

--- a/docs/_docs/installation/configure.md
+++ b/docs/_docs/installation/configure.md
@@ -15,8 +15,7 @@ Environment variables override file configuration values.
 | --------------------- | ----------------------------------------------------------------- | ------- |
 | `GITHUB_APP_ID`       | Configures the GitHub Application ID                              | *none*  |
 | `GITHUB_APP_PAGE`     | *(optional)* Points to the GitHub App public page. The value can be found on the GitHub App configuration page. | *none* |
-| `GITHUB_APP_KEYFILE`  | A path pointing to the GitHub App private key file                | `gh-app.pem`  |
-| `GITHUB_APP_PEM`      | Contents will be written to `./gh-app.pem` on startup             | *none*  |
+| `GITHUB_APP_KEYFILE`  | A path pointing to the GitHub App private key file                | `gh-app.pem` |
 | `GITHUB_BASE`         | Configures the GitHub API base URL (useful for GitHub Enterprise) | `https://api.github.com`  |
 | `GITHUB_SECRET`       | Configures the GitHub webhook secret                              | *none*  |
 | `GITHUB_DEBUG`        | Controls debug mode of octokit                                    | `false` |


### PR DESCRIPTION
use volume mounts for github application key files exclusively
